### PR TITLE
Fix for Comments where length > 4000

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -4611,7 +4611,7 @@ function Update-SCSMPropertyCollection
             {
                 foreach ($obj in $Object.ObjectCollection)
                 {
-                    Update-SCSMPropertyCollection -Object $obj
+                    Update-SCSMPropertyCollection -Object $obj -Alias $alias
                 }
             }
         }


### PR DESCRIPTION
Added from 
$commenttoAdd.substring(0,4000)

to 
commentToAdd = $commenttoAdd.substring(0,4000)
